### PR TITLE
Minor typo in ajax/admin

### DIFF
--- a/routes/ajax/admin.js
+++ b/routes/ajax/admin.js
@@ -31,7 +31,7 @@ var broadcast = function (req, res) {
         return;
     }
 
-    log.debug(req.session.user.name + '' + req.session.user.id + ' sent broadcast: ' + text);
+    log.debug(req.session.user.name + '/' + req.session.user.id + ' sent broadcast: ' + text);
 
     Chat.global.sendSystemMessage(text);
 
@@ -43,7 +43,7 @@ var broadcast = function (req, res) {
 };
 
 var restart = function (req, res) {
-    log.info(req.session.user.name + '' + req.session.user.id + ' triggered application restart');
+    log.info(req.session.user.name + '/' + req.session.user.id + ' triggered application restart');
 
     res.send(200);
 


### PR DESCRIPTION
Upon MOTD change, log displays `[username][id] changed MOTD: [motd]`. Ex: `tjhorner1 changed MOTD: bleh` instead of `[username]/[id]`.
