### PR TITLE
Add custom sets, fix a few bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I don't really recommend it.
 
 * node.js
 * Postgres (9?) database
-* npm install grunt-cli
+* `sudo npm install -g grunt-cli`
 
 ### Installation
 

--- a/app.js
+++ b/app.js
@@ -42,6 +42,7 @@ hbs.handlebars.registerPartial('chatMessage', fs.readFileSync(__dirname + '/view
 
 hbs.handlebars.registerPartial('modalGameSettings', fs.readFileSync(__dirname + '/views/game/modal_settings.hbs', 'utf8'));
 hbs.handlebars.registerPartial('modalGamePlayers', fs.readFileSync(__dirname + '/views/game/modal_players.hbs', 'utf8'));
+hbs.handlebars.registerPartial('modalAddSet', fs.readFileSync(__dirname + '/views/game/modal_add_set.hbs', 'utf8'));
 
 hbs.handlebars.registerPartial('cookieNotice', fs.readFileSync(__dirname + '/views/util/cookie_notice.hbs', 'utf8'));
 

--- a/data/decks/b_002_regulars.json
+++ b/data/decks/b_002_regulars.json
@@ -531,13 +531,19 @@
         "Seto's Livestream.",
         "Sketchy's enormous instrument.",
         "Dark Aura.",
+        "Regulus."
+        "Regulus' fuzzy fennec ears."
         "Hennet's Butt Pimple.",
         "Heat_Wave's masturbating birds.",
         "Changeling_Derpy.",
         "Sharing Pussy™ with all your friends.",
         "A can of juicy Pussy™.",
-        "Lycan’s Apple Bloom fetish.",
-        "Lycan’s special Apple Bloom plushie.",
-        "Yiffmaster 4000"
+        "Lycan's Apple Bloom fetish.",
+        "Lycan's special Apple Bloom plushie.",
+        "Yiffmaster 4000.",
+        "Eywind.",
+        "Eywind's non-existent OC.",
+        "Eywind's total aversion to ears.",
+        "Eywind's super secret deck."
     ]
 }

--- a/data/decks/b_002_regulars.json
+++ b/data/decks/b_002_regulars.json
@@ -531,8 +531,8 @@
         "Seto's Livestream.",
         "Sketchy's enormous instrument.",
         "Dark Aura.",
-        "Regulus."
-        "Regulus' fuzzy fennec ears."
+        "Regulus.",
+        "Regulus' fuzzy fennec ears.",
         "Hennet's Butt Pimple.",
         "Heat_Wave's masturbating birds.",
         "Changeling_Derpy.",

--- a/lib/game.js
+++ b/lib/game.js
@@ -37,6 +37,25 @@ var trace = function (game, message) {
     log.trace('Game ' + game.id + ': ' + message);
 };
 
+// for converting a custom set card into the format
+// for the game
+var customSetCardFormatted = function(card, index, watermark){
+  var cardText;
+  if(card.text){ // then it's a black card
+    cardText = card.text;
+  }else if(typeof(card) === "string"){ // else it's white
+    cardText = card;
+  }
+  return {
+    id: -index,
+    text: cardText,
+    toJSON: function(){
+      // yes, custom set IDs are negative.
+      return { id: -index, text: cardText, watermark: watermark };
+    }
+  };
+};
+
 var Player = function (user) {
 
     this.user = user;
@@ -117,6 +136,15 @@ var Game = function (host) {
      * @type {Array}
      */
     this.bans = [];
+
+    // custom expansion packs
+
+    /**
+     * Custom set to be used for the game.
+     * TODO add multiple custom sets?
+     * @type {Object}
+     */
+    this.customSet;
 
     this.addPlayer = function (user) {
         this.pushGlobalUpdate(constants.Server.Update.PLAYER_JOIN, {id: user.id, name: user.name});
@@ -280,8 +308,18 @@ var Game = function (host) {
         this.sendUpdates();
     };
 
+    this.setCustomSet = function(set){
+      this.customSet = set;
+
+      _.each(this.players, function (player) {
+        self.pushUpdate(player.user, constants.Server.Update.GAME_DATA, self.toJsonFormat(true));
+      });
+
+      this.sendUpdates();
+    };
+
     this.start = function () {
-        if (this.state != constants.State.LOBBY || this.players.length < 3 || this.sets.length == 0) {
+        if (this.state != constants.State.LOBBY || this.players.length < 3 || (this.sets.length == 0 && !this.customSet)) {
             return;
         }
 
@@ -297,6 +335,17 @@ var Game = function (host) {
                 });
             });
         });
+
+        if(this.customSet){
+          _.each(this.customSet.blackCards, function(card, index){
+            self.blackCards.push(customSetCardFormatted(card, index, "Custom"));
+          });
+
+          _.each(this.customSet.whiteCards, function(card, index){
+            self.whiteCards.push(customSetCardFormatted(card, index, "Custom"));
+            self.allWhiteCards.push(customSetCardFormatted(card, index, "Custom"));
+          });
+        }
 
         this.blackCards = _.shuffle(this.blackCards);
         this.whiteCards = _.shuffle(this.whiteCards);
@@ -756,7 +805,8 @@ var Game = function (host) {
             }),
             passworded: this.password != null && this.password.length !== 0,
             hidden: this.hidden,
-            state: this.state
+            state: this.state,
+            customSet: this.customSet
         };
 
         if (includePassword) {

--- a/package.json
+++ b/package.json
@@ -1,29 +1,30 @@
 {
-    "name": "cards-against-equestria",
-    "version": "1.0.7",
-    "homepage": "https://github.com/Rylius/CardsAgainstEquestria",
-    "private": true,
-    "scripts": {
-        "start": "node app.js"
-    },
-    "dependencies": {
-        "express": "3.x.x",
-        "connect-flash": "0.1.x",
-        "hbs": "2.4.x",
-        "handlebars-layouts": "0.1.x",
-        "underscore": "*",
-        "underscore.string": "*",
-        "extend": "1.2.x",
-        "logule": "2.x.x",
-        "sql": "~0.34.0",
-        "orm": "~2.1.3",
-        "pg": "~2.11.0"
-    },
-    "devDependencies": {
-        "grunt": "~0.4.2",
-        "grunt-contrib-less": "~0.8.3",
-        "grunt-contrib-concat": "~0.3.0",
-        "grunt-contrib-uglify": "~0.2.7",
-        "grunt-contrib-copy": "~0.5.0"
-    }
+  "name": "cards-against-equestria",
+  "version": "1.0.7",
+  "homepage": "https://github.com/Rylius/CardsAgainstEquestria",
+  "private": true,
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "cah-creator": "^1.0.0",
+    "connect-flash": "0.1.x",
+    "express": "3.x.x",
+    "extend": "1.2.x",
+    "handlebars-layouts": "0.1.x",
+    "hbs": "2.4.x",
+    "logule": "2.x.x",
+    "orm": "~2.1.3",
+    "pg": "~2.11.0",
+    "sql": "~0.34.0",
+    "underscore": "*",
+    "underscore.string": "*"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.2",
+    "grunt-contrib-less": "~0.8.3",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-uglify": "~0.2.7",
+    "grunt-contrib-copy": "~0.5.0"
+  }
 }

--- a/public/js/view/lobby.js
+++ b/public/js/view/lobby.js
@@ -15,6 +15,7 @@ var GameLobbyViewModel = function (user) {
 
     this.sets = ko.observableArray();
     this.expansions = ko.observableArray();
+
     this.rules = ko.observableArray();
 
     this.starting = ko.observable(false);
@@ -110,8 +111,31 @@ var GameLobbyViewModel = function (user) {
             }
         );
 
-        // FIXME This is hacky at best, let's try and do it better later...
-        $('title').text(self.game().name() + ' - Cards Against Equestria');
+        document.title = self.game().name() + ' - Cards Against Equestria';
+    };
+
+    this.addSetFromId = function (form) {
+      var $form = $(form);
+      $form.find(".loader").show();
+      $form.find(".btn, #cah-creator-id").prop("disabled", true);
+      $.ajax('/ajax/game/' + self.game().id() + '/addSet', {
+          method: 'post',
+          data: { cahCreatorId: $form.find("input").val() },
+          success: function(res){
+            $form.find(".loader").hide();
+            if(res.error){
+              $form.find(".btn, #cah-creator-id").prop("disabled", false);
+            }else{
+              $("#custom-set-info").slideDown();
+              $("#custom-set-name").text(res.name);
+            }
+          },
+          error: function(){
+            $form.find(".loader").hide();
+            $form.find(".btn, #cah-creator-id").prop("disabled", false);
+          }
+        }
+      );
     };
 
     // TODO duplicated in cards.js
@@ -189,8 +213,8 @@ var GameLobbyViewModel = function (user) {
             this.game().fromJson(data);
             this.sendUpdates(true);
 
-            // FIXME cleanup title change
-            $('title').text(data.name + ' - Cards Against Equestria');
+            document.title = data.name + ' - Cards Against Equestria'; // TODO should the app name (in this case "Cards Against Equestria") be stored in the
+                                                                       // config or something? this would be a pain to change everywhere.
         } else if (type == Game.Server.Update.CHAT) {
             if (data.user) {
                 console.log('Chat message by ' + data.user.id + '/' + data.user.name + ': ' + data.type + ': ' + data.message);

--- a/res/database/cae.sql
+++ b/res/database/cae.sql
@@ -32,7 +32,7 @@ SET client_min_messages = warning;
 
 --
 -- TOC entry 170 (class 3079 OID 11681)
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
@@ -41,7 +41,7 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 --
 -- TOC entry 1969 (class 0 OID 0)
 -- Dependencies: 170
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
@@ -72,7 +72,7 @@ SET default_with_oids = false;
 --
 -- TOC entry 168 (class 1259 OID 19435)
 -- Dependencies: 1827 5
--- Name: black_card; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: black_card; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE black_card (
@@ -89,7 +89,7 @@ ALTER TABLE public.black_card OWNER TO cae;
 --
 -- TOC entry 163 (class 1259 OID 19335)
 -- Dependencies: 1822 1823 1824 1825 5
--- Name: deck; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: deck; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE deck (
@@ -107,7 +107,7 @@ ALTER TABLE public.deck OWNER TO cae;
 --
 -- TOC entry 166 (class 1259 OID 19410)
 -- Dependencies: 5
--- Name: deck_permissions; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: deck_permissions; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE deck_permissions (
@@ -121,7 +121,7 @@ ALTER TABLE public.deck_permissions OWNER TO cae;
 --
 -- TOC entry 164 (class 1259 OID 19389)
 -- Dependencies: 1826 5
--- Name: permission; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: permission; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE permission (
@@ -135,7 +135,7 @@ ALTER TABLE public.permission OWNER TO cae;
 --
 -- TOC entry 167 (class 1259 OID 19425)
 -- Dependencies: 5
--- Name: site_permissions; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: site_permissions; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE site_permissions (
@@ -149,7 +149,7 @@ ALTER TABLE public.site_permissions OWNER TO cae;
 --
 -- TOC entry 161 (class 1259 OID 19316)
 -- Dependencies: 1819 1820 1821 5
--- Name: user; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: user; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE "user" (
@@ -169,7 +169,7 @@ ALTER TABLE public."user" OWNER TO cae;
 --
 -- TOC entry 165 (class 1259 OID 19395)
 -- Dependencies: 5
--- Name: user_permissions; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: user_permissions; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE user_permissions (
@@ -183,7 +183,7 @@ ALTER TABLE public.user_permissions OWNER TO cae;
 --
 -- TOC entry 169 (class 1259 OID 19449)
 -- Dependencies: 1828 5
--- Name: white_card; Type: TABLE; Schema: public; Owner: cae; Tablespace: 
+-- Name: white_card; Type: TABLE; Schema: public; Owner: cae; Tablespace:
 --
 
 CREATE TABLE white_card (
@@ -287,7 +287,7 @@ COPY white_card (id, deck_id, text) FROM stdin;
 --
 -- TOC entry 1842 (class 2606 OID 19443)
 -- Dependencies: 168 168 1963
--- Name: black_card_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: black_card_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY black_card
@@ -297,7 +297,7 @@ ALTER TABLE ONLY black_card
 --
 -- TOC entry 1838 (class 2606 OID 19414)
 -- Dependencies: 166 166 166 1963
--- Name: deck_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: deck_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY deck_permissions
@@ -307,7 +307,7 @@ ALTER TABLE ONLY deck_permissions
 --
 -- TOC entry 1832 (class 2606 OID 19346)
 -- Dependencies: 163 163 1963
--- Name: deck_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: deck_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY deck
@@ -317,7 +317,7 @@ ALTER TABLE ONLY deck
 --
 -- TOC entry 1834 (class 2606 OID 19394)
 -- Dependencies: 164 164 1963
--- Name: permission_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: permission_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY permission
@@ -327,7 +327,7 @@ ALTER TABLE ONLY permission
 --
 -- TOC entry 1840 (class 2606 OID 19429)
 -- Dependencies: 167 167 167 1963
--- Name: site_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: site_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY site_permissions
@@ -337,7 +337,7 @@ ALTER TABLE ONLY site_permissions
 --
 -- TOC entry 1836 (class 2606 OID 19399)
 -- Dependencies: 165 165 165 1963
--- Name: user_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: user_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY user_permissions
@@ -347,7 +347,7 @@ ALTER TABLE ONLY user_permissions
 --
 -- TOC entry 1830 (class 2606 OID 19325)
 -- Dependencies: 161 161 1963
--- Name: user_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: user_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY "user"
@@ -357,7 +357,7 @@ ALTER TABLE ONLY "user"
 --
 -- TOC entry 1844 (class 2606 OID 19457)
 -- Dependencies: 169 169 1963
--- Name: white_card_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace: 
+-- Name: white_card_pkey; Type: CONSTRAINT; Schema: public; Owner: cae; Tablespace:
 --
 
 ALTER TABLE ONLY white_card
@@ -451,4 +451,3 @@ GRANT ALL ON SCHEMA public TO PUBLIC;
 --
 -- PostgreSQL database dump complete
 --
-

--- a/views/game/lobby.hbs
+++ b/views/game/lobby.hbs
@@ -37,6 +37,7 @@
 
         <!-- ko with: game() -->
         {{> modalGamePlayers}}
+        {{> modalAddSet}}
         <!-- /ko -->
 
         <div id="lobby">
@@ -259,6 +260,11 @@
 
                 <span class="help-block">
                     Select any number
+                    <!-- ko if: isHost() -->
+                    <br>
+                    {{! TODO way of letting users know that the host added a custom set besides chat }}
+                    <a data-toggle="modal" data-target="#add-set-modal" href="#">Add custom set</a>
+                    <!-- /ko -->
                 </span>
 
                 <div data-bind="foreach: expansions">

--- a/views/game/modal_add_set.hbs
+++ b/views/game/modal_add_set.hbs
@@ -1,0 +1,54 @@
+<div id="add-set-modal" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                        aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">
+                    Add custom set
+                </h4>
+            </div>
+
+            <div class="modal-body">
+                <b>Step 1:</b>
+                <br>
+                Go to CAH Creator by <a href="http://cahcreator.com/partner/cae?game_id={{game.id}}" target="_blank">clicking here.</a>
+                Create your deck. Once you're done, head over to step 2.
+                <br><br>
+
+                <b>Step 2:</b>
+                <br>
+                Great! (Oh, also note that decks on cahcreator.com aren't stored permanently. Export your deck!)
+                Let's add your deck to this game. It won't be stored on the server and will only be available
+                to play this game.
+                <br><br>
+                Copy and paste the CAH Creator deck ID here (click "Export Deck" -> look at "Deck ID"):
+                <br><br>
+                <form class="form-inline" data-bind="submit: $root.addSetFromId">
+                  <div class="form-group">
+                    <label for="cah-creator-id">Deck ID</label>
+                    <input type="text" class="form-control" id="cah-creator-id" placeholder="abc123xyz">
+                  </div>
+                  <br><br>
+                  <button type="submit" class="btn btn-default">
+                    Add Custom Set
+                  </button>
+                  <span class="loader" style="display: none"> {{! if there's a better way to do this w/ ko, please let me know! }}
+                    {{ajaxLoader}}
+                  </span>
+                </form>
+                <br>
+                <div id="custom-set-info" style="display: none">
+                  <b>Success! Your custom set:</b> <span id="custom-set-name"></span> {{! again, if there's a better way with ko please tell me lol }}
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">
+                    Close
+                </button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This pull request adds integration with [cahcreator.com](http://cahcreator.com), a lightweight, collaborative Cards Against Humanity deck creator. Game hosts will be able to add custom decks to their games via the deck ID on CAH Creator; they will not be permanently stored on the server. However, decks must have at least 3 black cards and 5 white cards. They do count as expansions, so users will still need to pick a main deck.

I don't really know Knockout.js that well, so if you find anything that could be improved with it, please tell me! I added some TODOs where I believe that the code could be improved or a feature could be added.

I'm probably going to be adding raw JSON import if you don't merge this right away -- so if you want to use that instead of some shady third-party service, then hold off from merging it until then. :wink: ([CAH Creator is actually open-source...](/tjhorner/cah-creator))

Oh, and don't mind the whitespace removal on the migrations, it should't affect them. Atom likes saving bytes.

## Things that need to be fixed or added
- Auto adding sets (as in, a button on CAH Creator to add to your current game)
- Add the custom set to the expansions once it's added and disable the modal (right now, users get notified through chat that the host added a custom set)

(when I fixed the merge conflict, it apparently still had the commits from master. they don't seem to be a problem but I can close and re-open this again with them removed if you want, I was just too lazy and it's 11:30 PM here)