### PR TITLE
Improve CAH Creator integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "cah-creator": "^1.0.1",
+    "cah-creator": "^1.0.2",
     "connect-flash": "0.1.x",
     "express": "3.x.x",
     "extend": "1.2.x",

--- a/public/js/view/lobby.js
+++ b/public/js/view/lobby.js
@@ -152,7 +152,7 @@ var GameLobbyViewModel = function (user) {
     };
 
     this.addCustomSetFromId = function () {
-      self.cahCreatorWindow = window.open("http://localhost:3000/decks/select", "_blank", "height=620,width=1150");
+      self.cahCreatorWindow = window.open("https://cahcreator.com/decks/select", "_blank", "height=620,width=1150");
     };
 
     this.removeCustomSet = function (deck) {

--- a/public/js/view/lobby.js
+++ b/public/js/view/lobby.js
@@ -19,6 +19,39 @@ var GameLobbyViewModel = function (user) {
     this.addCustomSetId = ko.observable('');
     this.addCustomSetLoading = ko.observable(false);
     this.addCustomSetMessage = ko.observable(null);
+    this.cahCreatorWindow = undefined; // for now...
+
+    window.addEventListener("message", function(event){
+      if(event.data.deck){
+        self.cahCreatorWindow.close();
+
+        self.addCustomSetLoading(true);
+        self.addCustomSetMessage(null);
+        $.ajax('/ajax/game/' + self.game().id() + '/addSet', {
+                method: 'post',
+                data: {cahCreatorId: event.data.deck},
+                success: function (data) {
+                    data.id = event.data.deck;
+                    if (data !== 'OK') {
+                        self.game().customSets.push(data);
+                        self.update();
+
+                        self.addCustomSetMessage('Deck added: ' + data.name + ' - ' + data.description);
+                    } else {
+                        self.addCustomSetMessage('Deck has already been added');
+                    }
+                    self.addCustomSetId('');
+                },
+                error: function () {
+                    self.addCustomSetMessage('There doesn\'t seem to be any deck with that ID. :(')
+                },
+                complete: function () {
+                    self.addCustomSetLoading(false);
+                }
+            }
+        );
+      }
+    }, false);
 
     this.rules = ko.observableArray();
 
@@ -119,31 +152,7 @@ var GameLobbyViewModel = function (user) {
     };
 
     this.addCustomSetFromId = function () {
-        self.addCustomSetLoading(true);
-        self.addCustomSetMessage(null);
-        $.ajax('/ajax/game/' + self.game().id() + '/addSet', {
-                method: 'post',
-                data: {cahCreatorId: self.addCustomSetId()},
-                success: function (data) {
-                    data.id = self.addCustomSetId();
-                    if (data !== 'OK') {
-                        self.game().customSets.push(data);
-                        self.update();
-
-                        self.addCustomSetMessage('Deck added: ' + data.name + ' - ' + data.description);
-                    } else {
-                        self.addCustomSetMessage('Deck has already been added');
-                    }
-                    self.addCustomSetId('');
-                },
-                error: function () {
-                    self.addCustomSetMessage('There doesn\'t seem to be any deck with that ID. :(')
-                },
-                complete: function () {
-                    self.addCustomSetLoading(false);
-                }
-            }
-        );
+      self.cahCreatorWindow = window.open("http://localhost:3000/decks/select", "_blank", "height=620,width=1150");
     };
 
     this.removeCustomSet = function (deck) {

--- a/routes/ajax/game.js
+++ b/routes/ajax/game.js
@@ -121,7 +121,6 @@ var addSet = function (req, res) {
         res.send(200);
     } else if (deckId) {
         creatorApi.getDeck(deckId, function (deck) {
-            console.log(deck);
             if (deck.error) {
                 res.send(404); // the only error the api returns is not found so this is safe... for now...
                 return;

--- a/routes/ajax/game.js
+++ b/routes/ajax/game.js
@@ -121,6 +121,7 @@ var addSet = function (req, res) {
         res.send(200);
     } else if (deckId) {
         creatorApi.getDeck(deckId, function (deck) {
+            console.log(deck);
             if (deck.error) {
                 res.send(404); // the only error the api returns is not found so this is safe... for now...
                 return;

--- a/views/game/modal_add_set.hbs
+++ b/views/game/modal_add_set.hbs
@@ -15,35 +15,23 @@
 
                 <p>
                     Go to CAH Creator by
-                    <a href="http://cahcreator.com/partner/cae?game_id={{game.id}}" target="_blank">clicking here</a>.
-                    Create your deck. Once you're done, head over to step 2.
+                    <a href="https://cahcreator.com/" target="_blank">clicking here</a>.
+                    Sign up and create your deck. Once you're done, head over to step 2.
                 </p>
 
                 <h4>Step 2:</h4>
 
                 <p>
-                    Great! (Oh, also note that decks on cahcreator.com aren't stored permanently. Export your deck!)
-                    Let's add your deck to this game. It won't be stored on the server and will only be available
-                    to play this game.
-                </p>
-
-                <p>
-                    Copy and paste the CAH Creator deck ID here (click "Export Deck" -> look at "Deck ID"):
+                    Great! Now click this magical button to select your new deck:
                 </p>
 
                 <div class="row">
 
                     <div class="col-xs-6">
                         <form data-bind="submit: $root.addCustomSetFromId">
-                            <div class="form-group">
-                                <label for="customDeckId">Deck ID</label>
-                                <input type="text" class="form-control" placeholder="abc123xyz"
-                                       data-bind="value: $root.addCustomSetId" id="customDeckId">
-                            </div>
-
                             <button type="submit" class="btn btn-default"
                                     data-bind="disable: $root.addCustomSetLoading">
-                                Add custom deck
+                                Select Deck
                             </button>
                         </form>
                     </div>


### PR DESCRIPTION
CAH Creator 2.0 is out, and I want to improve some stuff here too! The biggest change is that now there's a picker window instead of having to manually type the deck ID in:

![image](https://cloud.githubusercontent.com/assets/2646487/15808245/d3ec32be-2b27-11e6-81d8-cc201b01166d.png)

There was also a bump of the `cah-creator` module to 1.0.2 which fixed a big error that caused successful requests to throw errors.